### PR TITLE
Fix CMF files playing slower than their MIDI equivalents

### DIFF
--- a/src/InputLibraryWrapper/FluidsynthWrapper.cpp
+++ b/src/InputLibraryWrapper/FluidsynthWrapper.cpp
@@ -525,7 +525,7 @@ void FluidsynthWrapper::AddEvent(smf_event_t *event, double offset)
         double scale = GetTempoScale(uspqn, event->track->smf->ppqn);
         CLOG(LogLevel_t::Debug, "Tempo: " << uspqn << " usPQN, " << scale << " scale, " << 60000000.0 / uspqn << " BPM, ppqn: " << event->track->smf->ppqn);
 
-        this->ScheduleTempoChange(scale, event->time_pulses + offset);
+        this->ScheduleTempoChange(scale, event->time_pulses + offset, false);
 
         return;
     }
@@ -642,12 +642,12 @@ void FluidsynthWrapper::InformHasProgChange(int chan)
 }
 
 
-void FluidsynthWrapper::ScheduleTempoChange(double newScale, int atTick)
+void FluidsynthWrapper::ScheduleTempoChange(double newScale, int atTick, bool absolute)
 {
     CLOG(LogLevel_t::Debug, "TEMPO CHANGE! newScale: " << newScale << ", atTick " << atTick);
     fluid_event_scale(this->synthEvent, newScale);
 
-    int ret = fluid_sequencer_send_at(this->sequencer, this->synthEvent, atTick, false);
+    int ret = fluid_sequencer_send_at(this->sequencer, this->synthEvent, atTick, absolute);
     if (ret != FLUID_OK)
     {
         CLOG(LogLevel_t::Error, "fluidsynth was unable to queue midi event");

--- a/src/InputLibraryWrapper/FluidsynthWrapper.cpp
+++ b/src/InputLibraryWrapper/FluidsynthWrapper.cpp
@@ -602,7 +602,7 @@ void FluidsynthWrapper::AddEvent(smf_event_t *event, double offset)
 
 void FluidsynthWrapper::AddEvent(fluid_event_t *event, uint32_t tick)
 {
-    if (tick + fluid_sequencer_get_tick(this->sequencer) >= this->lastTick)
+    if (tick >= this->lastTick)
     {
         return;
     }

--- a/src/InputLibraryWrapper/FluidsynthWrapper.h
+++ b/src/InputLibraryWrapper/FluidsynthWrapper.h
@@ -50,7 +50,7 @@ class FluidsynthWrapper
     void AddEvent(smf_event_t *event, double offset = 0.0);
     void AddEvent(fluid_event_t *event, uint32_t tick);
     void ScheduleLoop(MidiLoopInfo *loopInfo);
-    void ScheduleTempoChange(double newScale, int atTick);
+    void ScheduleTempoChange(double newScale, int atTick, bool absolute);
     void FinishSong(int millisec);
 
     void Render(float *bufferToFill, frame_t framesToRender);

--- a/src/InputLibraryWrapper/N64CSeqWrapper.cpp
+++ b/src/InputLibraryWrapper/N64CSeqWrapper.cpp
@@ -724,7 +724,7 @@ void N64CSeqWrapper::handleMetaMsg(CSeqState *seq, CSeqEvent *event, bool dispat
 
             if (dispatchEvent)
             {
-                this->synth->ScheduleTempoChange(FluidsynthWrapper::GetTempoScale(tempo, seq->division), seq->lastTicks);
+                this->synth->ScheduleTempoChange(FluidsynthWrapper::GetTempoScale(tempo, seq->division), seq->lastTicks, true);
             }
         }
     }


### PR DESCRIPTION
fluidsynth's sequencer introduced a relative errror. This is now documented in fluidsynth's API doc.

Solution: Schedule events by an absolute tick value.
Fixes #69.